### PR TITLE
[WIP] AppVeyor updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ project(node-iohook)
 if(WIN32 OR WIN64)
   #add libuihook project
   set(_config_headers "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/include/config.h")
-  file(GLOB SOURCE_UIHOOK_FILES "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src/logger.c"
+  file(GLOB SOURCE_UIHOOK_FILES "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/include/uiohook.h"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src/logger.c"
                                 "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src/logger.h"
                                 "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/input_helper.h"
                                 "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/input_helper.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,17 @@ project(node-iohook)
 
 if(WIN32 OR WIN64)
   #add libuihook project
-  add_subdirectory(libuiohook ${CMAKE_CURRENT_SOURCE_DIR}/build/libuiohook)
-
+  set(_config_headers "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/include/config.h")
+  file(GLOB SOURCE_UIHOOK_FILES "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src/logger.c"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src/logger.h"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/input_helper.h"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/input_helper.c"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/input_hook.c"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/post_event.c"
+                                "${CMAKE_CURRENT_SOURCE_DIR}/src/windows/system_properties.c")
+  add_library( "uiohook" STATIC ${SOURCE_UIHOOK_FILES} )
+  set_target_properties("uiohook"  PROPERTIES COMPILE_FLAGS "-Dinline=__inline -D_CRT_SECURE_NO_WARNINGS")
+  target_include_directories("uiohook" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/include" "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/src" "${CMAKE_CURRENT_SOURCE_DIR}/libuiohook/windows")
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 
   #bootstrap and configure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,25 @@
-# http://www.appveyor.com/docs/appveyor-yml
-
-# Test against these versions of Io.js and Node.js.
-environment:
-  os: Visual Studio 2013
-  matrix:
-  # node.js
-    - nodejs_version: "6"
-os: Previous Visual Studio 2013
-
-# Install scripts. (runs after repo cloning)
-install:
-  - set PATH=C:\Program Files (x86)\MSBuild\12.0\Bin;%PATH%
-  # Get the latest stable version of Node 0.STABLE.latest
-  - git submodule update --init
-  - ps: Install-Product node $env:nodejs_version
-  - npm -g install npm
-  # Typical npm stuff.
-  - npm install
-
-# Post-install test scripts.
-test_script:
-  # Output useful info for debugging.
-  - node --version
-  - npm --version
-  - npm test
-
-# Don't actually build.
-build: off
-
-# Set build version format here instead of in the admin panel.
+os: Visual Studio 2015
 version: "{build}"
+build: off
+skip_tags: true
+
+environment:
+  matrix:
+    - nodejs_version: "7"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm -g i npm@latest
+  - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
+  - set PATH=C:\Program Files (x86)\MSBuild\12.0\Bin;%PATH%
+  - npm i --ignore-scripts
+  - for /f %%i in ('node -v') do set exact_nodejs_version=%%i
+  - git submodule update --init --recursive
+  - cmake-js.cmd compile
+
+on_success:
+ - for %%i in (prebuilds\*) do appveyor PushArtifact %%i


### PR DESCRIPTION
Hey hey!

I have been trying to make prebuilds of either `node-iohook` or the `iohook` package.
It's been rough so far =)

However, I at least got it to start compiling something, and producing actual compilation errors that hopefully lead us to a solution soon.

Here is the failing build: https://ci.appveyor.com/project/vespakoen/node-iohook/build/3/job/1l0gc19lrpw11vwj

And here are the relevant errors:

```
node-iohook.obj : error LNK2019: unresolved external symbol _hook_set_dispatch_proc referenced in function "public: virtual void __thiscall HookProcessWorker::Execute(class Nan::AsyncProgressWorkerBase<struct _uiohook_event>::ExecutionProgress const &)" (?Execute@HookProcessWorker@@UAEXABVExecutionProgress@?$AsyncProgressWorkerBase@U_uiohook_event@@@Nan@@@Z) [C:\projects\node-iohook\build\node-iohook.vcxproj]
node-iohook.obj : error LNK2019: unresolved external symbol _hook_run referenced in function "public: virtual void __thiscall HookProcessWorker::Execute(class Nan::AsyncProgressWorkerBase<struct _uiohook_event>::ExecutionProgress const &)" (?Execute@HookProcessWorker@@UAEXABVExecutionProgress@?$AsyncProgressWorkerBase@U_uiohook_event@@@Nan@@@Z) [C:\projects\node-iohook\build\node-iohook.vcxproj]
node-iohook.obj : error LNK2019: unresolved external symbol _hook_stop referenced in function "public: void __thiscall HookProcessWorker::Stop(void)" (?Stop@HookProcessWorker@@QAEXXZ) [C:\projects\node-iohook\build\node-iohook.vcxproj]
```

Compiling `iohook` with the settings in this pull, yields something like this: https://ci.appveyor.com/project/vespakoen/iohook/build/job/i06vnvm59na05k0d

I know I am getting closer, but this is literally the first time I am compiling C++ on Windows, so I don't really know what I am doing ;)

It would also be great if you can shed some light on the reason for there being 2 packages trying to achieve the same thing, I guess one of you simply didn't notice the other package was around?

I hope this helps!